### PR TITLE
Change the BASE_PATH to match the mountpoint for /node

### DIFF
--- a/.env
+++ b/.env
@@ -16,7 +16,7 @@ POSTGRES_PASSWORD="password123"
 POSTGRES_DB="cexplorer"
 DB_SYNC_POSTGRES_CONNECTION_STRING="psql://postgres:password123@x.x.x.x:5432/cexplorer" # Replace x.x.x.x with IP or host to postgres connection
 
-BASE_PATH="./data/chains/partner_chains_template"
+BASE_PATH="./node/chain/"
 
 # start with one boot node:
 ARGS=--chain=/res/testnet/testnetRaw.json --bootnodes /dns/boot-node-01.testnet.midnight.network/tcp/30333/ws/p2p/12D3KooWMjUq13USCvQR9Y6yFzYNYgTQBLNAcmc8psAuPx2UUdnB


### PR DESCRIPTION
There does not appear to be anything stored in the `midnight-data-testnet` volume when mounted to /node. This PR changes the mountpoint to `/data` which is where the DB, keystore, etc. are being created.

Closes #1 