### PR TITLE
fix: cleanup .env file using new BOOTNODES var

### DIFF
--- a/.env
+++ b/.env
@@ -7,26 +7,12 @@ POSTGRES_PASSWORD="4sJHMjjEAGEi"
 POSTGRES_DB="cexplorer"
 DB_SYNC_POSTGRES_CONNECTION_STRING="psql://postgres:4sJHMjjEAGEi@x.x.x.x:5432/cexplorer" # Replace x.x.x.x with IP or host to postgres connection
 
-BASE_PATH="./node/chain/"
+BOOTNODES="/dns/boot-node-01.testnet.midnight.network/tcp/30333/ws/p2p/12D3KooWMjUq13USCvQR9Y6yFzYNYgTQBLNAcmc8psAuPx2UUdnB \
+           /dns/boot-node-02.testnet.midnight.network/tcp/30333/ws/p2p/12D3KooWR1cHBUWPCqk3uqhwZqUFekfWj8T7ozK6S18DUT745v4d \
+           /dns/boot-node-03.testnet.midnight.network/tcp/30333/ws/p2p/12D3KooWQxxUgq7ndPfAaCFNbAxtcKYxrAzTxDfRGNktF75SxdX5"
 
-# start with one boot node:
-# ARGS=--chain=/res/testnet/testnetRaw.json --bootnodes /dns/boot-node-01.testnet.midnight.network/tcp/30333/ws/p2p/12D3KooWMjUq13USCvQR9Y6yFzYNYgTQBLNAcmc8psAuPx2UUdnB
-  
-# start with debug:
-#ARGS=--chain=/res/testnet/testnetRaw.json --bootnodes /dns/boot-node-01.testnet.midnight.network/tcp/30333/ws/p2p/12D3KooWMjUq13USCvQR9Y6yFzYNYgTQBLNAcmc8psAuPx2UUdnB -l debug  
-
-# start with multiple boot nodes:
-#ARGS=--chain=/res/testnet/testnetRaw.json --bootnodes /dns/boot-node-01.testnet.midnight.network/tcp/30333/ws/p2p/12D3KooWMjUq13USCvQR9Y6yFzYNYgTQBLNAcmc8psAuPx2UUdnB --bootnodes /dns/node-03.testnet.midnight.network/tcp/30333/ws/p2p/12D3KooWQxxUgq7ndPfAaCFNbAxtcKYxrAzTxDfRGNktF75SxdX5
-
-# start as a validator:
-ARGS="--chain=/res/testnet/testnetRaw.json \
---bootnodes /dns/boot-node-01.testnet.midnight.network/tcp/30333/ws/p2p/12D3KooWMjUq13USCvQR9Y6yFzYNYgTQBLNAcmc8psAuPx2UUdnB \
---bootnodes /dns/boot-node-02.testnet.midnight.network/tcp/30333/ws/p2p/12D3KooWR1cHBUWPCqk3uqhwZqUFekfWj8T7ozK6S18DUT745v4d \
---bootnodes /dns/boot-node-03.testnet.midnight.network/tcp/30333/ws/p2p/12D3KooWQxxUgq7ndPfAaCFNbAxtcKYxrAzTxDfRGNktF75SxdX5 \
---no-private-ip \
---validator \
---pool-limit 10
-"
+# To start with debug logs, add "-l debug" to APPEND_ARGS
+APPEND_ARGS="--no-private-ip --validator --pool-limit 10"
 
 CFG_PRESET=testnet
 

--- a/.env
+++ b/.env
@@ -1,11 +1,11 @@
 MIDNIGHT_NODE_IMAGE="midnightnetwork/midnight-node:0.7.0"
 
-POSTGRES_HOST="postgres"
+POSTGRES_HOST="x.x.x.x" # Replace x.x.x.x with IP or host to postgres connection
 POSTGRES_PORT="5432"
 POSTGRES_USER="postgres"
 POSTGRES_PASSWORD="4sJHMjjEAGEi"
 POSTGRES_DB="cexplorer"
-DB_SYNC_POSTGRES_CONNECTION_STRING="psql://postgres:4sJHMjjEAGEi@x.x.x.x:5432/cexplorer" # Replace x.x.x.x with IP or host to postgres connection
+DB_SYNC_POSTGRES_CONNECTION_STRING="psql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB"
 
 BOOTNODES="/dns/boot-node-01.testnet.midnight.network/tcp/30333/ws/p2p/12D3KooWMjUq13USCvQR9Y6yFzYNYgTQBLNAcmc8psAuPx2UUdnB \
            /dns/boot-node-02.testnet.midnight.network/tcp/30333/ws/p2p/12D3KooWR1cHBUWPCqk3uqhwZqUFekfWj8T7ozK6S18DUT745v4d \


### PR DESCRIPTION
- Removes unnecessary setting of BASE_PATH and CHAIN
- Makes use of new BOOTNODES var

Closes #5 