### PR TITLE
Update .env to clarify the contents of NODE_KEY

### DIFF
--- a/.env
+++ b/.env
@@ -17,5 +17,5 @@ APPEND_ARGS="--no-private-ip --validator --pool-limit 10"
 CFG_PRESET=testnet
 
 # Validator Values:
-# generate node key like this: docker run --rm -it docker.io/parity/subkey:latest generate-node-key. Use the second output for NODE_KEY
+# generate node key like this: docker run --rm -it docker.io/parity/subkey:latest generate-node-key. Use the first output for NODE_KEY (contents of the secret_ed25519 file)
 NODE_KEY=""


### PR DESCRIPTION
Clarifies NODE_KEY is the contents of the secret_ed25519 file and not the public key contained in the second output of generate-node-key.

Closes #18 