### PR TITLE
remove node key

### DIFF
--- a/.env
+++ b/.env
@@ -11,11 +11,7 @@ BOOTNODES="/dns/boot-node-01.testnet.midnight.network/tcp/30333/ws/p2p/12D3KooWM
            /dns/boot-node-02.testnet.midnight.network/tcp/30333/ws/p2p/12D3KooWR1cHBUWPCqk3uqhwZqUFekfWj8T7ozK6S18DUT745v4d \
            /dns/boot-node-03.testnet.midnight.network/tcp/30333/ws/p2p/12D3KooWQxxUgq7ndPfAaCFNbAxtcKYxrAzTxDfRGNktF75SxdX5"
 
-# To start with debug logs, add "-l debug" to APPEND_ARGS
+# Appends cli args to the node binary. Explore all available options by passing --help.
 APPEND_ARGS="--no-private-ip --validator --pool-limit 10"
 
 CFG_PRESET=testnet
-
-# Validator Values:
-# generate node key like this: docker run --rm -it docker.io/parity/subkey:latest generate-node-key. Use the second output for NODE_KEY
-NODE_KEY=""


### PR DESCRIPTION
Removes the node key env var. The partnerchains wizard generates and inserts this key, so the env var override is not needed.