### PR TITLE
Update cardano node resources in light of issue

### DIFF
--- a/compose-partner-chains.yml
+++ b/compose-partner-chains.yml
@@ -7,7 +7,7 @@ volumes:
 
 services:
   cardano-node:
-    image: ghcr.io/intersectmbo/cardano-node:9.1.0
+    image: ghcr.io/intersectmbo/cardano-node:10.1.4 
     restart: unless-stopped
     container_name: cardano-node
     ports:
@@ -36,7 +36,7 @@ services:
       retries: 5
 
   db-sync:
-    image: ghcr.io/intersectmbo/cardano-db-sync:13.3.0.0
+    image: ghcr.io/intersectmbo/cardano-db-sync:13.5.0.2
     container_name: db-sync
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
As the title says. 

Updates partner-chains resources to maintain compatibility with Cardano preview testnet.