### PR TITLE
Expose Prometheus to host. Clean container name.

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ BOOTNODES="/dns/boot-node-01.testnet-02.midnight.network/tcp/30333/ws/p2p/12D3Ko
            /dns/boot-node-03.testnet-02.midnight.network/tcp/30333/ws/p2p/12D3KooWQxxUgq7ndPfAaCFNbAxtcKYxrAzTxDfRGNktF75SxdX5"
 
 # To start with debug logs, add "-l debug" to APPEND_ARGS
-APPEND_ARGS="--no-private-ip --validator --pool-limit 10 --trie-cache-size 0"
+APPEND_ARGS="--no-private-ip --validator --pool-limit 10 --trie-cache-size 0 --prometheus-external"
 
 CFG_PRESET=testnet-02
 

--- a/compose.yml
+++ b/compose.yml
@@ -3,11 +3,13 @@ volumes:
 
 services:
   midnight-node-testnet:
+    container_name: midnight
     image: ${MIDNIGHT_NODE_IMAGE}
     platform: linux/amd64
     ports:
       - "9944:9944"
       - "30333:30333"
+      - "9615:9615"
     env_file:
       - ./.env
     healthcheck:


### PR DESCRIPTION
1. Expose Prometheus port - The Prometheus service is made accessible to the host machine, enabling easier monitoring and integration with external observability tools.
2. Clean container name - The container is given a more usable name, simplifying reference in Docker commands.