### PR TITLE
chore(env): Update environment variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,11 +1,9 @@
 MIDNIGHT_NODE_IMAGE="midnightnetwork/midnight-node:0.8.0"
 
-POSTGRES_HOST="x.x.x.x" # Replace x.x.x.x with IP or host to postgres connection
 POSTGRES_PORT="5432"
 POSTGRES_USER="postgres"
 POSTGRES_PASSWORD="4sJHMjjEAGEi"
 POSTGRES_DB="cexplorer"
-DB_SYNC_POSTGRES_CONNECTION_STRING="psql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB"
 
 BOOTNODES="/dns/boot-node-01.testnet-02.midnight.network/tcp/30333/ws/p2p/12D3KooWMjUq13USCvQR9Y6yFzYNYgTQBLNAcmc8psAuPx2UUdnB \
            /dns/boot-node-02.testnet-02.midnight.network/tcp/30333/ws/p2p/12D3KooWR1cHBUWPCqk3uqhwZqUFekfWj8T7ozK6S18DUT745v4d \

--- a/.env
+++ b/.env
@@ -1,9 +1,11 @@
 MIDNIGHT_NODE_IMAGE="midnightnetwork/midnight-node:0.8.0"
 
+POSTGRES_HOST="x.x.x.x" # Replace x.x.x.x with IP or host to postgres connection
 POSTGRES_PORT="5432"
 POSTGRES_USER="postgres"
 POSTGRES_PASSWORD="4sJHMjjEAGEi"
 POSTGRES_DB="cexplorer"
+DB_SYNC_POSTGRES_CONNECTION_STRING="psql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB"
 
 BOOTNODES="/dns/boot-node-01.testnet-02.midnight.network/tcp/30333/ws/p2p/12D3KooWMjUq13USCvQR9Y6yFzYNYgTQBLNAcmc8psAuPx2UUdnB \
            /dns/boot-node-02.testnet-02.midnight.network/tcp/30333/ws/p2p/12D3KooWR1cHBUWPCqk3uqhwZqUFekfWj8T7ozK6S18DUT745v4d \

--- a/compose-partner-chains.yml
+++ b/compose-partner-chains.yml
@@ -23,8 +23,9 @@ services:
     image: postgres:15.3
     container_name: db-sync-postgres
     environment:
+      - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_DB=cexplorer
+      - POSTGRES_DB=${POSTGRES_DB}
     volumes:
       - postgres-data:/var/lib/postgresql/data
     ports:
@@ -45,9 +46,9 @@ services:
     environment:
       - NETWORK=preview
       - POSTGRES_HOST=postgres
-      - POSTGRES_PORT=5432
-      - POSTGRES_DB=cexplorer
-      - POSTGRES_USER=postgres
+      - POSTGRES_PORT=${POSTGRES_PORT}
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     volumes:
       - ${HOME_IPC}:/node-ipc  # Use ${HOME_IPC} from .env


### PR DESCRIPTION
The current setup of docker compose is not using the values set in `.env`, e.g. `POSTGRES_USER` is hardcoded to `postgres` in the `db-sync` service. This causes errors when attempting to start the service with this repo as-is. 

This PR: makes it use env vars from `.env` in the docker compose `compose-partner-chains.yml` file.

Testing

Running `docker compose -f compose-partner-chains.yml up -d` brings all the services up without errors.

