### PR TITLE
Set restart policy

### DIFF
--- a/.env
+++ b/.env
@@ -12,6 +12,7 @@ BOOTNODES="/dns/boot-node-01.testnet-02.midnight.network/tcp/30333/ws/p2p/12D3Ko
            /dns/boot-node-03.testnet-02.midnight.network/tcp/30333/ws/p2p/12D3KooWQxxUgq7ndPfAaCFNbAxtcKYxrAzTxDfRGNktF75SxdX5"
 
 # To start with debug logs, add "-l debug" to APPEND_ARGS
+# To expose safe rpc method to the host port 9944, add "--rpc-external" to APPEND_ARGS
 APPEND_ARGS="--no-private-ip --validator --pool-limit 10 --trie-cache-size 0 --prometheus-external"
 
 CFG_PRESET=testnet-02

--- a/compose.yml
+++ b/compose.yml
@@ -4,6 +4,7 @@ volumes:
 services:
   midnight-node-testnet:
     container_name: midnight
+    restart: unless-stopped
     image: ${MIDNIGHT_NODE_IMAGE}
     platform: linux/amd64
     ports:


### PR DESCRIPTION
Assuming Docker is set to start on boot, and the Midnight container was last running, start the container after a reboot.