### PR TITLE
Proof server improvement

### DIFF
--- a/proof-server.yml
+++ b/proof-server.yml
@@ -3,4 +3,4 @@ services:
     image: midnightnetwork/proof-server:3.0.7
     ports:
       - "6300:6300"
-    command: ["midnight-proof-server", "--network", "testnet-02"]
+    command: "'midnight-proof-server --network testnet'"

--- a/proof-server.yml
+++ b/proof-server.yml
@@ -4,3 +4,5 @@ services:
     ports:
       - "6300:6300"
     command: "'midnight-proof-server --network testnet'"
+    healthcheck:
+      test: ["CMD", "/bin/bash", "-c", ":> /dev/tcp/127.0.0.1/6300 || exit 1"]


### PR DESCRIPTION
Proof server compose file fix...

Issue 1:
The correct proof server target network is 'testnet', rather than 'testnet-02'.

Issue 2:
The previous command would result in the Midnight network being 'Undefined', whereas we are targeting 'Testnet'.
You can see a discussion (and the solution) about this issue here in the Midnight Discord:
https://discord.com/channels/1165826384975908924/1209887476290682910/1353014023590777044

Additional improvement:
A working healthcheck has also been added to improve observability.

Thanks,
Adam